### PR TITLE
default stdout/stderr logging

### DIFF
--- a/6.0/6.0-dev/skeleton/etc/zope.ini
+++ b/6.0/6.0-dev/skeleton/etc/zope.ini
@@ -65,13 +65,13 @@ level = NOTSET
 formatter = generic
 
 [handler_accesslog]
-class = FileHandler
-args = ('/app/var/log/access.log','a')
+class = StreamHandler
+args = (sys.stdout,)
 level = INFO
 formatter = message
 
 [handler_eventlog]
-class = FileHandler
-args = ('/app/var/log/event.log', 'a')
+class = StreamHandler
+args = (sys.stderr,)
 level = INFO
 formatter = generic


### PR DESCRIPTION
Logging to stdout/stderr as pointed in [Best practices for writing Dockerfiles](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/), [Docker Logging: A Complete Guide](https://sematext.com/guides/docker-logs/)

See also https://github.com/plone/plone.docker/pull/159