### PR TITLE
Add busybox to provide most useful commands with a minimal footprint

### DIFF
--- a/5.2/5.2.6/Dockerfile.python36
+++ b/5.2/5.2.6/Dockerfile.python36
@@ -27,9 +27,10 @@ LABEL maintainer="Plone Community <dev@plone.org>" \
 COPY --from=builder /wheelhouse /wheelhouse
 
 RUN useradd --system -m -d /app -U -u 500 plone \
-    && runDeps="git libjpeg62 libopenjp2-7 libpq5 libtiff5 libxml2 libxslt1.1 lynx netcat poppler-utils rsync wv" \
+    && runDeps="git libjpeg62 libopenjp2-7 libpq5 libtiff5 libxml2 libxslt1.1 lynx netcat poppler-utils rsync wv busybox" \
     && apt-get update \
     && apt-get install -y --no-install-recommends $runDeps \
+    && busybox --install -s \
     && rm -rf /var/lib/apt/lists/* /usr/share/doc \
     && mkdir -p /data/filestorage /data/blobstorage /data/log /data/cache \
     && chown -R plone:plone /data

--- a/5.2/5.2.6/Dockerfile.python37
+++ b/5.2/5.2.6/Dockerfile.python37
@@ -27,9 +27,10 @@ LABEL maintainer="Plone Community <dev@plone.org>" \
 COPY --from=builder /wheelhouse /wheelhouse
 
 RUN useradd --system -m -d /app -U -u 500 plone \
-    && runDeps="git libjpeg62 libopenjp2-7 libpq5 libtiff5 libxml2 libxslt1.1 lynx netcat poppler-utils rsync wv" \
+    && runDeps="git libjpeg62 libopenjp2-7 libpq5 libtiff5 libxml2 libxslt1.1 lynx netcat poppler-utils rsync wv busybox" \
     && apt-get update \
     && apt-get install -y --no-install-recommends $runDeps \
+    && busybox --install -s \
     && rm -rf /var/lib/apt/lists/* /usr/share/doc \
     && mkdir -p /data/filestorage /data/blobstorage /data/log /data/cache \
     && chown -R plone:plone /data

--- a/5.2/5.2.6/Dockerfile.python38
+++ b/5.2/5.2.6/Dockerfile.python38
@@ -27,9 +27,10 @@ LABEL maintainer="Plone Community <dev@plone.org>" \
 COPY --from=builder /wheelhouse /wheelhouse
 
 RUN useradd --system -m -d /app -U -u 500 plone \
-    && runDeps="git libjpeg62 libopenjp2-7 libpq5 libtiff5 libxml2 libxslt1.1 lynx netcat poppler-utils rsync wv" \
+    && runDeps="git libjpeg62 libopenjp2-7 libpq5 libtiff5 libxml2 libxslt1.1 lynx netcat poppler-utils rsync wv busybox" \
     && apt-get update \
     && apt-get install -y --no-install-recommends $runDeps \
+    && busybox --install -s \
     && rm -rf /var/lib/apt/lists/* /usr/share/doc \
     && mkdir -p /data/filestorage /data/blobstorage /data/log /data/cache \
     && chown -R plone:plone /data

--- a/6.0/6.0-dev/Dockerfile.python37
+++ b/6.0/6.0-dev/Dockerfile.python37
@@ -28,9 +28,10 @@ LABEL maintainer="Plone Community <dev@plone.org>" \
 COPY --from=builder /wheelhouse /wheelhouse
 
 RUN useradd --system -m -d /app -U -u 500 plone \
-    && runDeps="git libjpeg62 libopenjp2-7 libpq5 libtiff5 libxml2 libxslt1.1 lynx netcat poppler-utils rsync wv" \
+    && runDeps="git libjpeg62 libopenjp2-7 libpq5 libtiff5 libxml2 libxslt1.1 lynx netcat poppler-utils rsync wv busybox" \
     && apt-get update \
     && apt-get install -y --no-install-recommends $runDeps \
+    && busybox --install -s \
     && rm -rf /var/lib/apt/lists/* /usr/share/doc \
     && mkdir -p /data/filestorage /data/blobstorage /data/log /data/cache \
     && chown -R plone:plone /data

--- a/6.0/6.0-dev/Dockerfile.python38
+++ b/6.0/6.0-dev/Dockerfile.python38
@@ -28,9 +28,10 @@ LABEL maintainer="Plone Community <dev@plone.org>" \
 COPY --from=builder /wheelhouse /wheelhouse
 
 RUN useradd --system -m -d /app -U -u 500 plone \
-    && runDeps="git libjpeg62 libopenjp2-7 libpq5 libtiff5 libxml2 libxslt1.1 lynx netcat poppler-utils rsync wv" \
+    && runDeps="git libjpeg62 libopenjp2-7 libpq5 libtiff5 libxml2 libxslt1.1 lynx netcat poppler-utils rsync wv busybox" \
     && apt-get update \
     && apt-get install -y --no-install-recommends $runDeps \
+    && busybox --install -s \
     && rm -rf /var/lib/apt/lists/* /usr/share/doc \
     && mkdir -p /data/filestorage /data/blobstorage /data/log /data/cache \
     && chown -R plone:plone /data

--- a/6.0/6.0-dev/Dockerfile.python39
+++ b/6.0/6.0-dev/Dockerfile.python39
@@ -28,9 +28,10 @@ LABEL maintainer="Plone Community <dev@plone.org>" \
 COPY --from=builder /wheelhouse /wheelhouse
 
 RUN useradd --system -m -d /app -U -u 500 plone \
-    && runDeps="git libjpeg62 libopenjp2-7 libpq5 libtiff5 libxml2 libxslt1.1 lynx netcat poppler-utils rsync wv" \
+    && runDeps="git libjpeg62 libopenjp2-7 libpq5 libtiff5 libxml2 libxslt1.1 lynx netcat poppler-utils rsync wv busybox" \
     && apt-get update \
     && apt-get install -y --no-install-recommends $runDeps \
+    && busybox --install -s \
     && rm -rf /var/lib/apt/lists/* /usr/share/doc \
     && mkdir -p /data/filestorage /data/blobstorage /data/log /data/cache \
     && chown -R plone:plone /data

--- a/6.0/6.0.0a1/Dockerfile.python37
+++ b/6.0/6.0.0a1/Dockerfile.python37
@@ -27,9 +27,10 @@ LABEL maintainer="Plone Community <dev@plone.org>" \
 COPY --from=builder /wheelhouse /wheelhouse
 
 RUN useradd --system -m -d /app -U -u 500 plone \
-    && runDeps="git libjpeg62 libopenjp2-7 libpq5 libtiff5 libxml2 libxslt1.1 lynx netcat poppler-utils rsync wv" \
+    && runDeps="git libjpeg62 libopenjp2-7 libpq5 libtiff5 libxml2 libxslt1.1 lynx netcat poppler-utils rsync wv busybox" \
     && apt-get update \
     && apt-get install -y --no-install-recommends $runDeps \
+    && busybox --install -s \
     && rm -rf /var/lib/apt/lists/* /usr/share/doc \
     && mkdir -p /data/filestorage /data/blobstorage /data/log /data/cache \
     && chown -R plone:plone /data

--- a/6.0/6.0.0a1/Dockerfile.python38
+++ b/6.0/6.0.0a1/Dockerfile.python38
@@ -27,9 +27,10 @@ LABEL maintainer="Plone Community <dev@plone.org>" \
 COPY --from=builder /wheelhouse /wheelhouse
 
 RUN useradd --system -m -d /app -U -u 500 plone \
-    && runDeps="git libjpeg62 libopenjp2-7 libpq5 libtiff5 libxml2 libxslt1.1 lynx netcat poppler-utils rsync wv" \
+    && runDeps="git libjpeg62 libopenjp2-7 libpq5 libtiff5 libxml2 libxslt1.1 lynx netcat poppler-utils rsync wv busybox" \
     && apt-get update \
     && apt-get install -y --no-install-recommends $runDeps \
+    && busybox --install -s \
     && rm -rf /var/lib/apt/lists/* /usr/share/doc \
     && mkdir -p /data/filestorage /data/blobstorage /data/log /data/cache \
     && chown -R plone:plone /data

--- a/6.0/6.0.0a1/Dockerfile.python39
+++ b/6.0/6.0.0a1/Dockerfile.python39
@@ -27,9 +27,10 @@ LABEL maintainer="Plone Community <dev@plone.org>" \
 COPY --from=builder /wheelhouse /wheelhouse
 
 RUN useradd --system -m -d /app -U -u 500 plone \
-    && runDeps="git libjpeg62 libopenjp2-7 libpq5 libtiff5 libxml2 libxslt1.1 lynx netcat poppler-utils rsync wv" \
+    && runDeps="git libjpeg62 libopenjp2-7 libpq5 libtiff5 libxml2 libxslt1.1 lynx netcat poppler-utils rsync wv busybox" \
     && apt-get update \
     && apt-get install -y --no-install-recommends $runDeps \
+    && busybox --install -s \
     && rm -rf /var/lib/apt/lists/* /usr/share/doc \
     && mkdir -p /data/filestorage /data/blobstorage /data/log /data/cache \
     && chown -R plone:plone /data


### PR DESCRIPTION
When entering a container to do some debugging many tools people are used to are missing.
Things lilke `ping` or `netstat` can be very useful when troubleshooting.
At the cost of about 5 Mb (uncompressed) `busybox` can provide a great value.