### PR TITLE
Bring back the SITE creation environment variable

### DIFF
--- a/5.2/5.2.6/skeleton/docker-entrypoint.sh
+++ b/5.2/5.2.6/skeleton/docker-entrypoint.sh
@@ -70,6 +70,19 @@ if [[ -v DEVELOP ]]; then
   gosu plone /app/bin/pip install --editable "${DEVELOP}" ${PIP_PARAMS}
 fi
 
+# Handle Site creation
+if [[ -v SITE ]]; then
+  export TYPE=${TYPE:-volto}
+  echo "======================================================================================="
+  echo "Creating Plone ${TYPE} SITE: ${SITE}"
+  echo "Aditional profiles: ${PROFILES}"
+  echo "THIS IS NOT MEANT TO BE USED IN PRODUCTION"
+  echo "Read about it: https://github.com/plone/plone-backend/#extending-from-this-image"
+  echo "======================================================================================="
+  export SITE_ID=${SITE}
+  gosu plone /app/bin/zconsole run etc/${CONF} /app/scripts/create_site.py
+fi
+
 if [[ "$1" == "start" ]]; then
   exec gosu plone /app/bin/runwsgi -v etc/zope.ini config_file=${CONF}
 elif  [[ "$1" == "create-classic" ]]; then

--- a/5.2/5.2.6/skeleton/scripts/create_site.py
+++ b/5.2/5.2.6/skeleton/scripts/create_site.py
@@ -37,7 +37,7 @@ SETUP_CONTENT = asbool(os.getenv("SETUP_CONTENT"))
 DELETE_EXISTING = asbool(os.getenv("DELETE_EXISTING"))
 LANGUAGE = os.getenv("LANGUAGE", "en")
 TIMEZONE = os.getenv("TIMEZONE", "Europe/Berlin")
-ADDITIONAL_PROFILES = os.getenv("ADDITIONAL_PROFILES", "")
+ADDITIONAL_PROFILES = os.getenv("PROFILES", os.getenv("ADDITIONAL_PROFILES", ""))
 
 PROFILES = {
     "volto": [
@@ -80,6 +80,7 @@ if SITE_ID in app.objectIds() and DELETE_EXISTING:
     transaction.commit()
     app._p_jar.sync()
 
-site = addPloneSite(app, SITE_ID, **payload)
-transaction.commit()
-app._p_jar.sync()
+if SITE_ID not in app.objectIds():
+    site = addPloneSite(app, SITE_ID, **payload)
+    transaction.commit()
+    app._p_jar.sync()

--- a/6.0/6.0-dev/skeleton/docker-entrypoint.sh
+++ b/6.0/6.0-dev/skeleton/docker-entrypoint.sh
@@ -70,6 +70,19 @@ if [[ -v DEVELOP ]]; then
   gosu plone /app/bin/pip install --editable "${DEVELOP}" ${PIP_PARAMS}
 fi
 
+# Handle Site creation
+if [[ -v SITE ]]; then
+  export TYPE=${TYPE:-volto}
+  echo "======================================================================================="
+  echo "Creating Plone ${TYPE} SITE: ${SITE}"
+  echo "Aditional profiles: ${PROFILES}"
+  echo "THIS IS NOT MEANT TO BE USED IN PRODUCTION"
+  echo "Read about it: https://github.com/plone/plone-backend/#extending-from-this-image"
+  echo "======================================================================================="
+  export SITE_ID=${SITE}
+  gosu plone /app/bin/zconsole run etc/${CONF} /app/scripts/create_site.py
+fi
+
 if [[ "$1" == "start" ]]; then
   exec gosu plone /app/bin/runwsgi -v etc/zope.ini config_file=${CONF}
 elif  [[ "$1" == "create-classic" ]]; then

--- a/6.0/6.0-dev/skeleton/scripts/create_site.py
+++ b/6.0/6.0-dev/skeleton/scripts/create_site.py
@@ -37,7 +37,7 @@ SETUP_CONTENT = asbool(os.getenv("SETUP_CONTENT"))
 DELETE_EXISTING = asbool(os.getenv("DELETE_EXISTING"))
 LANGUAGE = os.getenv("LANGUAGE", "en")
 TIMEZONE = os.getenv("TIMEZONE", "Europe/Berlin")
-ADDITIONAL_PROFILES = os.getenv("ADDITIONAL_PROFILES", "")
+ADDITIONAL_PROFILES = os.getenv("PROFILES", os.getenv("ADDITIONAL_PROFILES", ""))
 
 PROFILES = {
     "volto": [
@@ -80,6 +80,7 @@ if SITE_ID in app.objectIds() and DELETE_EXISTING:
     transaction.commit()
     app._p_jar.sync()
 
-site = addPloneSite(app, SITE_ID, **payload)
-transaction.commit()
-app._p_jar.sync()
+if SITE_ID not in app.objectIds():
+    site = addPloneSite(app, SITE_ID, **payload)
+    transaction.commit()
+    app._p_jar.sync()

--- a/6.0/6.0.0a1/skeleton/docker-entrypoint.sh
+++ b/6.0/6.0.0a1/skeleton/docker-entrypoint.sh
@@ -70,16 +70,29 @@ if [[ -v DEVELOP ]]; then
   gosu plone /app/bin/pip install --editable "${DEVELOP}" ${PIP_PARAMS}
 fi
 
+# Handle Site creation
+if [[ -v SITE ]]; then
+  export TYPE=${TYPE:-volto}
+  echo "======================================================================================="
+  echo "Creating Plone ${TYPE} SITE: ${SITE}"
+  echo "Aditional profiles: ${PROFILES}"
+  echo "THIS IS NOT MEANT TO BE USED IN PRODUCTION"
+  echo "Read about it: https://github.com/plone/plone-backend/#extending-from-this-image"
+  echo "======================================================================================="
+  export SITE_ID=${SITE}
+  gosu plone /app/bin/zconsole run etc/${CONF} /app/scripts/create_site.py
+fi
+
 if [[ "$1" == "start" ]]; then
   exec gosu plone /app/bin/runwsgi -v etc/zope.ini config_file=${CONF}
 elif  [[ "$1" == "create-classic" ]]; then
-  TYPE=classic
+  export TYPE=classic
   exec gosu plone /app/bin/zconsole run etc/${CONF} /app/scripts/create_site.py
 elif  [[ "$1" == "create-volto" ]]; then
-  TYPE=volto
+  export TYPE=volto
   exec gosu plone /app/bin/zconsole run etc/${CONF} /app/scripts/create_site.py
 elif  [[ "$1" == "create-site" ]]; then
-  TYPE=volto
+  export TYPE=volto
   exec gosu plone /app/bin/zconsole run etc/${CONF} /app/scripts/create_site.py
 else
   # Custom

--- a/6.0/6.0.0a1/skeleton/scripts/create_site.py
+++ b/6.0/6.0.0a1/skeleton/scripts/create_site.py
@@ -37,7 +37,7 @@ SETUP_CONTENT = asbool(os.getenv("SETUP_CONTENT"))
 DELETE_EXISTING = asbool(os.getenv("DELETE_EXISTING"))
 LANGUAGE = os.getenv("LANGUAGE", "en")
 TIMEZONE = os.getenv("TIMEZONE", "Europe/Berlin")
-ADDITIONAL_PROFILES = os.getenv("ADDITIONAL_PROFILES", "")
+ADDITIONAL_PROFILES = os.getenv("PROFILES", os.getenv("ADDITIONAL_PROFILES", ""))
 
 PROFILES = {
     "volto": [
@@ -80,6 +80,7 @@ if SITE_ID in app.objectIds() and DELETE_EXISTING:
     transaction.commit()
     app._p_jar.sync()
 
-site = addPloneSite(app, SITE_ID, **payload)
-transaction.commit()
-app._p_jar.sync()
+if SITE_ID not in app.objectIds():
+    site = addPloneSite(app, SITE_ID, **payload)
+    transaction.commit()
+    app._p_jar.sync()

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ docker run -p 8080:8080 -e ADDONS="plone.volto==3.1.0a3" plone/plone-backend:6.0
 
 ### Developing packages
 
-It is possibile to install local packages instead of packages from pip. To do so, pass the **DEVELOP** environment variable with a list (separated by space) of paths to python packages to be installed.
+It is possible to install local packages instead of packages from pip. To do so, pass the **DEVELOP** environment variable with a list (separated by space) of paths to python packages to be installed.
 Those packages will be installed with ``pip install --editable``.
 
 
@@ -138,6 +138,24 @@ docker run -p 8080:8080 -e DEVELOP="/app/src/mysite.policy" -v /path/to/mysite.p
 
 > **NOTE**: We advise against using this feature on production environments.
 
+
+### Site creation
+
+It is possible to initialize your database with a Plone Site instance on first run. To do so, pass the **SITE** environment variable with the name of the Plone Site instance, e.g.: **SITE=Plone**. This will add a Volto ready Plone site. If you want a Plone classic instance, pass also **TYPE=classic** environment variable. To initialize it with additional profiles, just pass them, space separated, via **PROFILES** environment variable, e.g.: **PROFILES=eea.api.layout:default**. To recreate the Plone site on container restart you can pass the **DELETE_EXISTING** environment.
+
+Plone 6 example:
+
+```shell
+docker run -p 8080:8080 -e ADDONS="eea.api.layout" -e SITE="Plone" -e PROFILES="eea.api.layout:default" plone/plone-backend:6.0.0a1
+```
+
+Plone 6 Classic example:
+
+```shell
+docker run -p 8080:8080 -e ADDONS="eea.facetednavigation" -e SITE="Plone" -e TYPE="classic" -e PROFILES="eea.facetednavigation:default" plone/plone-backend:6.0.0a1
+```
+
+> **NOTE**: We advise against using this feature on production environments.
 
 ### Main variables
 


### PR DESCRIPTION
* This is very useful when you're developing Volto and you need to fire a Plone backend with one line of code. 
* Also needed with Volto cypress testing.