### PR TITLE
Fix logic to determine latest tag and pass it on to docker build GH action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Get tag from Makefile
         id: get-tag
         run: |
-          TAG="$(.github/workflows/collect-tags.py ${{ matrix.plone-version }})$(.github/workflows/is_latest.py ${{ matrix.plone-version }} ${{ matrix.python-version }})"
+          TAG="$(.github/workflows/collect-tags.py ${{ matrix.plone-version }})"
           echo Using tag ${TAG}
           echo "::set-output name=tag::${TAG}"
         env:

--- a/.github/workflows/collect-tags.py
+++ b/.github/workflows/collect-tags.py
@@ -5,14 +5,17 @@ collect all the tags in the images and print them as JSON.
 import os
 import sys
 import re
+from is_latest import is_latest
 
 
 def print_tags(path):
     makefile_contents = open(os.path.join(path, "Makefile")).read()
     python_version = os.environ.get("PYTHON_VERSION")
     image_tag = get_variable("IMAGE_TAG", makefile_contents)
-    print(f'plone/plone-backend:{image_tag}-python{python_version}')
-
+    print(f'plone/plone-backend:{image_tag}-python{python_version}', end="")
+    if is_latest(path.split("/")[1], python_version):
+        print(",plone/plone-backend:latest", end="")
+    print()
 
 def get_variable(variable_name, makefile_contents):
     """Naively extract a variable definition from a string representing a Makefile"""

--- a/.github/workflows/is_latest.py
+++ b/.github/workflows/is_latest.py
@@ -10,9 +10,7 @@ import collect_matrix
 from distutils.version import StrictVersion
 
 
-def main():
-    plone_version_to_examine = sys.argv[1].split("/")[1]
-    python_version_to_examine: str = sys.argv[2]
+def is_latest(plone_version_to_examine: str, python_version_to_examine: str):
     available_versions = []
     for el in collect_matrix.get_matrix():
         try:
@@ -25,7 +23,8 @@ def main():
     latest_plone_version = str(available_versions[-1][0])
     latest_python_version = str(available_versions[-1][1])
     if latest_plone_version == plone_version_to_examine and python_version_to_examine == str(latest_python_version):
-        print(",latest", end="")
+        return True
 
 if __name__ == '__main__':
-    main()
+    if is_latest(sys.argv[1].split("/")[1], sys.argv[2]):
+        print(",latest", end="")


### PR DESCRIPTION
The scripts that determined which image should receive the `latest` tag had a bug: the full image name was being specified as `latest` instead of `plone/plone-backend:latest`. This PR should fix that bug.

It looks like it's working: [the output of the _Get tag from Makefile_ step in the `3.8, 5.2/5.2.6` job](https://github.com/plone/plone-backend/runs/4212245304?check_suite_focus=true#step:4:8) is:
```
Using tag plone/plone-backend:5.2.6-python38,plone/plone-backend:latest
```
while [it used to be](https://github.com/plone/plone-backend/runs/4208758268?check_suite_focus=true#step:4:8):
```
Using tag plone/plone-backend:5.2.6-python38,latest
```
