### PR TITLE
Push generic tags

### DIFF
--- a/.github/workflows/collect-tags.py
+++ b/.github/workflows/collect-tags.py
@@ -5,15 +5,18 @@ collect all the tags in the images and print them as JSON.
 import os
 import sys
 import re
-from is_latest import is_latest
+from is_latest import is_latest, is_latest_supported_python
 
 
 def print_tags(path):
     makefile_contents = open(os.path.join(path, "Makefile")).read()
     python_version = os.environ.get("PYTHON_VERSION")
     image_tag = get_variable("IMAGE_TAG", makefile_contents)
+    plone_version = path.split("/")[1]
     print(f'plone/plone-backend:{image_tag}-python{python_version}', end="")
-    if is_latest(path.split("/")[1], python_version):
+    if is_latest_supported_python(plone_version, python_version):
+        print(f",plone/plone-backend:{image_tag}", end="")
+    if is_latest(plone_version, python_version):
         print(",plone/plone-backend:latest", end="")
     print()
 

--- a/.github/workflows/collect-tags.py
+++ b/.github/workflows/collect-tags.py
@@ -13,17 +13,20 @@ def print_tags(path):
     python_version = os.environ.get("PYTHON_VERSION")
     image_tag = get_variable("IMAGE_TAG", makefile_contents)
     plone_version = path.split("/")[1]
-    print(f'plone/plone-backend:{image_tag}-python{python_version}', end="")
+    print(f"plone/plone-backend:{image_tag}-python{python_version}", end="")
     if is_latest_supported_python(plone_version, python_version):
         print(f",plone/plone-backend:{image_tag}", end="")
     if is_latest(plone_version, python_version):
         print(",plone/plone-backend:latest", end="")
     print()
 
+
 def get_variable(variable_name, makefile_contents):
     """Naively extract a variable definition from a string representing a Makefile"""
-    return re.search(rf"^{variable_name}=(.*)", makefile_contents, re.MULTILINE).groups()[0]
+    return re.search(
+        rf"^{variable_name}=(.*)", makefile_contents, re.MULTILINE
+    ).groups()[0]
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     print_tags(sys.argv[1])

--- a/.github/workflows/collect_matrix.py
+++ b/.github/workflows/collect_matrix.py
@@ -12,7 +12,7 @@ def directories_on_level_2():
     in the current hierarchy,
     """
     for directory in os.listdir("."):
-        if not directory.startswith('.') and os.path.isdir(directory):
+        if not directory.startswith(".") and os.path.isdir(directory):
             for subdirectory in os.listdir(directory):
                 path = os.path.join(directory, subdirectory)
                 if os.path.isdir(path):
@@ -20,9 +20,8 @@ def directories_on_level_2():
 
 
 def filter_out_directories_starting_with_dot(directories):
-    """Return a list of directories without those starting with a dot
-    """
-    return [directory for directory in directories if not directory.startswith('.')]
+    """Return a list of directories without those starting with a dot"""
+    return [directory for directory in directories if not directory.startswith(".")]
 
 
 def get_matrix():
@@ -31,10 +30,10 @@ def get_matrix():
         for file in os.listdir(directory):
             if file.startswith("Dockerfile."):
                 yield {
-                    "python-version": file[len("Dockerfile.python"):],
+                    "python-version": file[len("Dockerfile.python") :],
                     "plone-version": directory,
                 }
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     print(json.dumps(list(get_matrix())))

--- a/.github/workflows/is_latest.py
+++ b/.github/workflows/is_latest.py
@@ -21,6 +21,7 @@ python_versions = {
     "311": "311",
 }
 
+
 def sortable_pyv(version):
     return python_versions.get(version, version)
 
@@ -29,11 +30,11 @@ def get_available_versions():
     available_versions = []
     for el in collect_matrix.get_matrix():
         try:
-            version = StrictVersion(el['plone-version'].split("/")[1])
+            version = StrictVersion(el["plone-version"].split("/")[1])
         except ValueError:
             continue
         if not version.prerelease:
-            available_versions.append((version, sortable_pyv(el['python-version'])))
+            available_versions.append((version, sortable_pyv(el["python-version"])))
     return sorted(available_versions)
 
 
@@ -41,19 +42,21 @@ def is_latest(plone_version_to_examine: str, python_version_to_examine: str):
     available_versions = get_available_versions()
     latest_plone_version = str(available_versions[-1][0])
     latest_python_version = str(available_versions[-1][1])
-    if latest_plone_version == plone_version_to_examine and sortable_pyv(python_version_to_examine) == str(latest_python_version):
+    if latest_plone_version == plone_version_to_examine and sortable_pyv(
+        python_version_to_examine
+    ) == str(latest_python_version):
         return True
 
 
 def is_latest_supported_python(plone_version, python_version):
     available_versions = []
     for el in collect_matrix.get_matrix():
-        if el['plone-version'].split("/")[1] == plone_version:
-            available_versions.append(sortable_pyv(el['python-version']))
+        if el["plone-version"].split("/")[1] == plone_version:
+            available_versions.append(sortable_pyv(el["python-version"]))
     available_versions.sort()
     return sortable_pyv(python_version) == available_versions[-1]
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     if is_latest(sys.argv[1].split("/")[1], sys.argv[2]):
         print(",latest", end="")

--- a/.github/workflows/is_latest.py
+++ b/.github/workflows/is_latest.py
@@ -10,7 +10,22 @@ import collect_matrix
 from distutils.version import StrictVersion
 
 
-def is_latest(plone_version_to_examine: str, python_version_to_examine: str):
+python_versions = {
+    # Map the python versions as used in tag names, Makefiles etc
+    # to lexycographically sortable versions
+    "36": "036",
+    "37": "037",
+    "38": "038",
+    "39": "039",
+    "310": "310",
+    "311": "311",
+}
+
+def sortable_pyv(version):
+    return python_versions.get(version, version)
+
+
+def get_available_versions():
     available_versions = []
     for el in collect_matrix.get_matrix():
         try:
@@ -18,12 +33,26 @@ def is_latest(plone_version_to_examine: str, python_version_to_examine: str):
         except ValueError:
             continue
         if not version.prerelease:
-            available_versions.append((version, int(el['python-version'])))
-    available_versions.sort()
+            available_versions.append((version, sortable_pyv(el['python-version'])))
+    return sorted(available_versions)
+
+
+def is_latest(plone_version_to_examine: str, python_version_to_examine: str):
+    available_versions = get_available_versions()
     latest_plone_version = str(available_versions[-1][0])
     latest_python_version = str(available_versions[-1][1])
-    if latest_plone_version == plone_version_to_examine and python_version_to_examine == str(latest_python_version):
+    if latest_plone_version == plone_version_to_examine and sortable_pyv(python_version_to_examine) == str(latest_python_version):
         return True
+
+
+def is_latest_supported_python(plone_version, python_version):
+    available_versions = []
+    for el in collect_matrix.get_matrix():
+        if el['plone-version'].split("/")[1] == plone_version:
+            available_versions.append(sortable_pyv(el['python-version']))
+    available_versions.sort()
+    return sortable_pyv(python_version) == available_versions[-1]
+
 
 if __name__ == '__main__':
     if is_latest(sys.argv[1].split("/")[1], sys.argv[2]):


### PR DESCRIPTION
When we push `plone/plone-backend:6.0.0a1-python39` we should also push the same image as `plone/plone-backend:6.0.0a1`, since `3.9` is the currently newer supported python version.

This PR adds that tag. The latest python version is determined by lexycographically comparing string representations of each python version. The representations are prepended a `0` if the python version is only two character long (it is currently the case for all supported versions, but this will change when we will start supporting python 3.10).