### PR TITLE
Move relstorage install to builder

### DIFF
--- a/5.2/5.2.6/Dockerfile.python36
+++ b/5.2/5.2.6/Dockerfile.python36
@@ -4,6 +4,7 @@ FROM base as builder
 ENV PIP_PARAMS="--use-deprecated legacy-resolver"
 ENV PLONE_VERSION=5.2.6
 ENV PLONE_VOLTO="plone.volto==3.1.0a2"
+ENV EXTRA_PACKAGES="relstorage==3.4.5 psycopg2-binary==2.9.1"
 
 RUN mkdir /wheelhouse
 
@@ -12,7 +13,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends $buildDeps\
     && rm -rf /var/lib/apt/lists/* /usr/share/doc
 
-RUN pip wheel Paste Plone ${PLONE_VOLTO} -c https://dist.plone.org/release/$PLONE_VERSION/constraints.txt  ${PIP_PARAMS} --wheel-dir=/wheelhouse
+RUN pip wheel Paste Plone ${PLONE_VOLTO} ${EXTRA_PACKAGES} -c https://dist.plone.org/release/$PLONE_VERSION/constraints.txt  ${PIP_PARAMS} --wheel-dir=/wheelhouse
 
 FROM base
 

--- a/5.2/5.2.6/Dockerfile.python36
+++ b/5.2/5.2.6/Dockerfile.python36
@@ -4,7 +4,7 @@ FROM base as builder
 ENV PIP_PARAMS="--use-deprecated legacy-resolver"
 ENV PLONE_VERSION=5.2.6
 ENV PLONE_VOLTO="plone.volto==3.1.0a2"
-ENV EXTRA_PACKAGES="relstorage==3.4.5 psycopg2-binary==2.9.1"
+ENV EXTRA_PACKAGES="relstorage==3.4.5 psycopg2==2.9.3"
 
 RUN mkdir /wheelhouse
 
@@ -41,7 +41,7 @@ WORKDIR /app
 RUN python -m venv . \
     && ./bin/pip install -U "pip==${PIP_VERSION}" \
     && ./bin/pip install --force-reinstall --no-index --no-deps ${PIP_PARAMS} /wheelhouse/* \
-    && ./bin/pip install "relstorage==3.4.5" "psycopg2-binary==2.9.1" ${PIP_PARAMS} \
+    && ./bin/pip install "relstorage==3.4.5" "psycopg2==2.9.3" ${PIP_PARAMS} \
     && find . \( -type f -a -name '*.pyc' -o -name '*.pyo' \) -exec rm -rf '{}' + \
     && rm -rf .cache
 

--- a/5.2/5.2.6/Dockerfile.python37
+++ b/5.2/5.2.6/Dockerfile.python37
@@ -4,7 +4,7 @@ FROM base as builder
 ENV PIP_PARAMS="--use-deprecated legacy-resolver"
 ENV PLONE_VERSION=5.2.6
 ENV PLONE_VOLTO="plone.volto==3.1.0a4"
-ENV EXTRA_PACKAGES="relstorage==3.4.5 psycopg2-binary==2.9.1"
+ENV EXTRA_PACKAGES="relstorage==3.4.5 psycopg2==2.9.3"
 
 RUN mkdir /wheelhouse
 
@@ -41,7 +41,7 @@ WORKDIR /app
 RUN python -m venv . \
     && ./bin/pip install -U "pip==${PIP_VERSION}" \
     && ./bin/pip install --force-reinstall --no-index --no-deps ${PIP_PARAMS} /wheelhouse/* \
-    && ./bin/pip install "relstorage==3.4.5" "psycopg2-binary==2.9.1" ${PIP_PARAMS} \
+    && ./bin/pip install "relstorage==3.4.5" "psycopg2==2.9.3" ${PIP_PARAMS} \
     && find . \( -type f -a -name '*.pyc' -o -name '*.pyo' \) -exec rm -rf '{}' + \
     && rm -rf .cache
 

--- a/5.2/5.2.6/Dockerfile.python37
+++ b/5.2/5.2.6/Dockerfile.python37
@@ -4,6 +4,7 @@ FROM base as builder
 ENV PIP_PARAMS="--use-deprecated legacy-resolver"
 ENV PLONE_VERSION=5.2.6
 ENV PLONE_VOLTO="plone.volto==3.1.0a4"
+ENV EXTRA_PACKAGES="relstorage==3.4.5 psycopg2-binary==2.9.1"
 
 RUN mkdir /wheelhouse
 
@@ -12,7 +13,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends $buildDeps\
     && rm -rf /var/lib/apt/lists/* /usr/share/doc
 
-RUN pip wheel Paste Plone ${PLONE_VOLTO} -c https://dist.plone.org/release/$PLONE_VERSION/constraints.txt  ${PIP_PARAMS} --wheel-dir=/wheelhouse
+RUN pip wheel Paste Plone ${PLONE_VOLTO} ${EXTRA_PACKAGES} -c https://dist.plone.org/release/$PLONE_VERSION/constraints.txt  ${PIP_PARAMS} --wheel-dir=/wheelhouse
 
 FROM base
 

--- a/5.2/5.2.6/Dockerfile.python38
+++ b/5.2/5.2.6/Dockerfile.python38
@@ -4,6 +4,7 @@ FROM base as builder
 ENV PIP_PARAMS="--use-deprecated legacy-resolver"
 ENV PLONE_VERSION=5.2.6
 ENV PLONE_VOLTO="plone.volto==3.1.0a4"
+ENV EXTRA_PACKAGES="relstorage==3.4.5 psycopg2-binary==2.9.1"
 
 RUN mkdir /wheelhouse
 
@@ -12,7 +13,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends $buildDeps\
     && rm -rf /var/lib/apt/lists/* /usr/share/doc
 
-RUN pip wheel Paste Plone ${PLONE_VOLTO} -c https://dist.plone.org/release/$PLONE_VERSION/constraints.txt  ${PIP_PARAMS} --wheel-dir=/wheelhouse
+RUN pip wheel Paste Plone ${PLONE_VOLTO} ${EXTRA_PACKAGES} -c https://dist.plone.org/release/$PLONE_VERSION/constraints.txt  ${PIP_PARAMS} --wheel-dir=/wheelhouse
 
 FROM base
 
@@ -40,7 +41,6 @@ WORKDIR /app
 RUN python -m venv . \
     && ./bin/pip install -U "pip==${PIP_VERSION}" \
     && ./bin/pip install --force-reinstall --no-index --no-deps ${PIP_PARAMS} /wheelhouse/* \
-    && ./bin/pip install "relstorage==3.4.5" "psycopg2-binary==2.9.1" ${PIP_PARAMS} \
     && find . \( -type f -a -name '*.pyc' -o -name '*.pyo' \) -exec rm -rf '{}' + \
     && rm -rf .cache
 

--- a/5.2/5.2.6/Dockerfile.python38
+++ b/5.2/5.2.6/Dockerfile.python38
@@ -4,7 +4,7 @@ FROM base as builder
 ENV PIP_PARAMS="--use-deprecated legacy-resolver"
 ENV PLONE_VERSION=5.2.6
 ENV PLONE_VOLTO="plone.volto==3.1.0a4"
-ENV EXTRA_PACKAGES="relstorage==3.4.5 psycopg2-binary==2.9.1"
+ENV EXTRA_PACKAGES="relstorage==3.4.5 psycopg2==2.9.3"
 
 RUN mkdir /wheelhouse
 

--- a/6.0/6.0-dev/Dockerfile.python37
+++ b/6.0/6.0-dev/Dockerfile.python37
@@ -3,7 +3,7 @@ FROM base as builder
 
 ENV PIP_PARAMS="--use-deprecated legacy-resolver"
 ENV PLONE_VERSION=6.0-dev
-ENV EXTRA_PACKAGES="relstorage==3.4.5 psycopg2-binary==2.9.1"
+ENV EXTRA_PACKAGES="relstorage==3.4.5 psycopg2==2.9.3"
 
 RUN mkdir /wheelhouse
 

--- a/6.0/6.0-dev/Dockerfile.python37
+++ b/6.0/6.0-dev/Dockerfile.python37
@@ -3,6 +3,7 @@ FROM base as builder
 
 ENV PIP_PARAMS="--use-deprecated legacy-resolver"
 ENV PLONE_VERSION=6.0-dev
+ENV EXTRA_PACKAGES="relstorage==3.4.5 psycopg2-binary==2.9.1"
 
 RUN mkdir /wheelhouse
 
@@ -11,7 +12,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends $buildDeps\
     && rm -rf /var/lib/apt/lists/* /usr/share/doc
 
-RUN pip wheel Plone -c https://dist.plone.org/release/$PLONE_VERSION/constraints.txt  ${PIP_PARAMS} --wheel-dir=/wheelhouse
+RUN pip wheel Plone ${EXTRA_PACKAGES} -c https://dist.plone.org/release/$PLONE_VERSION/constraints.txt  ${PIP_PARAMS} --wheel-dir=/wheelhouse
 
 FROM base
 
@@ -40,7 +41,7 @@ WORKDIR /app
 RUN python -m venv . \
     && ./bin/pip install -U "pip==${PIP_VERSION}" \
     && ./bin/pip install --force-reinstall --no-index --no-deps ${PIP_PARAMS} /wheelhouse/* \
-    && ./bin/pip install "plone.volto==${PLONE_VOLTO_VERSION}" "relstorage==3.4.5" "psycopg2-binary==2.9.1" ${PIP_PARAMS} \
+    && ./bin/pip install "plone.volto==${PLONE_VOLTO_VERSION}" ${PIP_PARAMS} \
     && find . \( -type f -a -name '*.pyc' -o -name '*.pyo' \) -exec rm -rf '{}' + \
     && rm -rf .cache
 

--- a/6.0/6.0-dev/Dockerfile.python38
+++ b/6.0/6.0-dev/Dockerfile.python38
@@ -3,7 +3,7 @@ FROM base as builder
 
 ENV PIP_PARAMS="--use-deprecated legacy-resolver"
 ENV PLONE_VERSION=6.0-dev
-ENV EXTRA_PACKAGES="relstorage==3.4.5 psycopg2-binary==2.9.1"
+ENV EXTRA_PACKAGES="relstorage==3.4.5 psycopg2==2.9.3"
 
 RUN mkdir /wheelhouse
 

--- a/6.0/6.0-dev/Dockerfile.python38
+++ b/6.0/6.0-dev/Dockerfile.python38
@@ -3,6 +3,7 @@ FROM base as builder
 
 ENV PIP_PARAMS="--use-deprecated legacy-resolver"
 ENV PLONE_VERSION=6.0-dev
+ENV EXTRA_PACKAGES="relstorage==3.4.5 psycopg2-binary==2.9.1"
 
 RUN mkdir /wheelhouse
 
@@ -11,7 +12,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends $buildDeps\
     && rm -rf /var/lib/apt/lists/* /usr/share/doc
 
-RUN pip wheel Plone -c https://dist.plone.org/release/$PLONE_VERSION/constraints.txt  ${PIP_PARAMS} --wheel-dir=/wheelhouse
+RUN pip wheel Plone ${EXTRA_PACKAGES} -c https://dist.plone.org/release/$PLONE_VERSION/constraints.txt  ${PIP_PARAMS} --wheel-dir=/wheelhouse
 
 FROM base
 
@@ -40,7 +41,7 @@ WORKDIR /app
 RUN python -m venv . \
     && ./bin/pip install -U "pip==${PIP_VERSION}" \
     && ./bin/pip install --force-reinstall --no-index --no-deps ${PIP_PARAMS} /wheelhouse/* \
-    && ./bin/pip install "plone.volto==${PLONE_VOLTO_VERSION}" "relstorage==3.4.5" "psycopg2-binary==2.9.1" ${PIP_PARAMS} \
+    && ./bin/pip install "plone.volto==${PLONE_VOLTO_VERSION}" ${PIP_PARAMS} \
     && find . \( -type f -a -name '*.pyc' -o -name '*.pyo' \) -exec rm -rf '{}' + \
     && rm -rf .cache
 

--- a/6.0/6.0-dev/Dockerfile.python39
+++ b/6.0/6.0-dev/Dockerfile.python39
@@ -3,7 +3,7 @@ FROM base as builder
 
 ENV PIP_PARAMS="--use-deprecated legacy-resolver"
 ENV PLONE_VERSION=6.0-dev
-ENV EXTRA_PACKAGES="relstorage==3.4.5 psycopg2-binary==2.9.1"
+ENV EXTRA_PACKAGES="relstorage==3.4.5 psycopg2==2.9.3"
 
 RUN mkdir /wheelhouse
 

--- a/6.0/6.0-dev/Dockerfile.python39
+++ b/6.0/6.0-dev/Dockerfile.python39
@@ -3,6 +3,7 @@ FROM base as builder
 
 ENV PIP_PARAMS="--use-deprecated legacy-resolver"
 ENV PLONE_VERSION=6.0-dev
+ENV EXTRA_PACKAGES="relstorage==3.4.5 psycopg2-binary==2.9.1"
 
 RUN mkdir /wheelhouse
 
@@ -11,7 +12,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends $buildDeps\
     && rm -rf /var/lib/apt/lists/* /usr/share/doc
 
-RUN pip wheel Plone -c https://dist.plone.org/release/$PLONE_VERSION/constraints.txt  ${PIP_PARAMS} --wheel-dir=/wheelhouse
+RUN pip wheel Plone ${EXTRA_PACKAGES} -c https://dist.plone.org/release/$PLONE_VERSION/constraints.txt  ${PIP_PARAMS} --wheel-dir=/wheelhouse
 
 FROM base
 
@@ -40,7 +41,7 @@ WORKDIR /app
 RUN python -m venv . \
     && ./bin/pip install -U "pip==${PIP_VERSION}" \
     && ./bin/pip install --force-reinstall --no-index --no-deps ${PIP_PARAMS} /wheelhouse/* \
-    && ./bin/pip install "plone.volto==${PLONE_VOLTO_VERSION}" "relstorage==3.4.5" "psycopg2-binary==2.9.1" ${PIP_PARAMS} \
+    && ./bin/pip install "plone.volto==${PLONE_VOLTO_VERSION}" ${PIP_PARAMS} \
     && find . \( -type f -a -name '*.pyc' -o -name '*.pyo' \) -exec rm -rf '{}' + \
     && rm -rf .cache
 

--- a/6.0/6.0.0a1/Dockerfile.python37
+++ b/6.0/6.0.0a1/Dockerfile.python37
@@ -3,6 +3,7 @@ FROM base as builder
 
 ENV PIP_PARAMS="--use-deprecated legacy-resolver"
 ENV PLONE_VERSION=6.0.0a1
+ENV EXTRA_PACKAGES="relstorage==3.4.5 psycopg2==2.9.3"
 
 RUN mkdir /wheelhouse
 
@@ -11,7 +12,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends $buildDeps\
     && rm -rf /var/lib/apt/lists/* /usr/share/doc
 
-RUN pip wheel Plone plone.volto -c https://dist.plone.org/release/$PLONE_VERSION/constraints.txt  ${PIP_PARAMS} --wheel-dir=/wheelhouse
+RUN pip wheel Plone plone.volto ${EXTRA_PACKAGES} -c https://dist.plone.org/release/$PLONE_VERSION/constraints.txt  ${PIP_PARAMS} --wheel-dir=/wheelhouse
 
 FROM base
 
@@ -39,7 +40,6 @@ WORKDIR /app
 RUN python -m venv . \
     && ./bin/pip install -U "pip==${PIP_VERSION}" \
     && ./bin/pip install --force-reinstall --no-index --no-deps ${PIP_PARAMS} /wheelhouse/* \
-    && ./bin/pip install "relstorage==3.4.5" "psycopg2==2.9.3" ${PIP_PARAMS} \
     && find . \( -type f -a -name '*.pyc' -o -name '*.pyo' \) -exec rm -rf '{}' + \
     && rm -rf .cache
 

--- a/6.0/6.0.0a1/Dockerfile.python37
+++ b/6.0/6.0.0a1/Dockerfile.python37
@@ -39,7 +39,7 @@ WORKDIR /app
 RUN python -m venv . \
     && ./bin/pip install -U "pip==${PIP_VERSION}" \
     && ./bin/pip install --force-reinstall --no-index --no-deps ${PIP_PARAMS} /wheelhouse/* \
-    && ./bin/pip install "relstorage==3.4.5" "psycopg2-binary==2.9.1" ${PIP_PARAMS} \
+    && ./bin/pip install "relstorage==3.4.5" "psycopg2==2.9.3" ${PIP_PARAMS} \
     && find . \( -type f -a -name '*.pyc' -o -name '*.pyo' \) -exec rm -rf '{}' + \
     && rm -rf .cache
 

--- a/6.0/6.0.0a1/Dockerfile.python38
+++ b/6.0/6.0.0a1/Dockerfile.python38
@@ -3,6 +3,7 @@ FROM base as builder
 
 ENV PIP_PARAMS="--use-deprecated legacy-resolver"
 ENV PLONE_VERSION=6.0.0a1
+ENV EXTRA_PACKAGES="relstorage==3.4.5 psycopg2==2.9.3"
 
 RUN mkdir /wheelhouse
 
@@ -11,7 +12,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends $buildDeps\
     && rm -rf /var/lib/apt/lists/* /usr/share/doc
 
-RUN pip wheel Plone plone.volto -c https://dist.plone.org/release/$PLONE_VERSION/constraints.txt  ${PIP_PARAMS} --wheel-dir=/wheelhouse
+RUN pip wheel Plone plone.volto ${EXTRA_PACKAGES} -c https://dist.plone.org/release/$PLONE_VERSION/constraints.txt  ${PIP_PARAMS} --wheel-dir=/wheelhouse
 
 FROM base
 

--- a/6.0/6.0.0a1/Dockerfile.python38
+++ b/6.0/6.0.0a1/Dockerfile.python38
@@ -39,7 +39,7 @@ WORKDIR /app
 RUN python -m venv . \
     && ./bin/pip install -U "pip==${PIP_VERSION}" \
     && ./bin/pip install --force-reinstall --no-index --no-deps ${PIP_PARAMS} /wheelhouse/* \
-    && ./bin/pip install "relstorage==3.4.5" "psycopg2-binary==2.9.1" ${PIP_PARAMS} \
+    && ./bin/pip install "relstorage==3.4.5" "psycopg2==2.9.3" ${PIP_PARAMS} \
     && find . \( -type f -a -name '*.pyc' -o -name '*.pyo' \) -exec rm -rf '{}' + \
     && rm -rf .cache
 

--- a/6.0/6.0.0a1/Dockerfile.python39
+++ b/6.0/6.0.0a1/Dockerfile.python39
@@ -3,6 +3,7 @@ FROM base as builder
 
 ENV PIP_PARAMS="--use-deprecated legacy-resolver"
 ENV PLONE_VERSION=6.0.0a1
+ENV EXTRA_PACKAGES="relstorage==3.4.5 psycopg2==2.9.3"
 
 RUN mkdir /wheelhouse
 
@@ -11,7 +12,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends $buildDeps\
     && rm -rf /var/lib/apt/lists/* /usr/share/doc
 
-RUN pip wheel Plone plone.volto -c https://dist.plone.org/release/$PLONE_VERSION/constraints.txt  ${PIP_PARAMS} --wheel-dir=/wheelhouse
+RUN pip wheel Plone plone.volto ${EXTRA_PACKAGES} -c https://dist.plone.org/release/$PLONE_VERSION/constraints.txt  ${PIP_PARAMS} --wheel-dir=/wheelhouse
 
 FROM base
 

--- a/6.0/6.0.0a1/Dockerfile.python39
+++ b/6.0/6.0.0a1/Dockerfile.python39
@@ -39,7 +39,7 @@ WORKDIR /app
 RUN python -m venv . \
     && ./bin/pip install -U "pip==${PIP_VERSION}" \
     && ./bin/pip install --force-reinstall --no-index --no-deps ${PIP_PARAMS} /wheelhouse/* \
-    && ./bin/pip install "relstorage==3.4.5" "psycopg2-binary==2.9.1" ${PIP_PARAMS} \
+    && ./bin/pip install "relstorage==3.4.5" "psycopg2==2.9.3" ${PIP_PARAMS} \
     && find . \( -type f -a -name '*.pyc' -o -name '*.pyo' \) -exec rm -rf '{}' + \
     && rm -rf .cache
 

--- a/6.0/6.0.0a2/Dockerfile.python37
+++ b/6.0/6.0.0a2/Dockerfile.python37
@@ -3,7 +3,7 @@ FROM base as builder
 
 ENV PIP_PARAMS="--use-deprecated legacy-resolver"
 ENV PLONE_VERSION=6.0.0a2
-ENV EXTRA_PACKAGES="relstorage==3.4.5 psycopg2-binary==2.9.1"
+ENV EXTRA_PACKAGES="relstorage==3.4.5 psycopg2==2.9.3"
 
 RUN mkdir /wheelhouse
 

--- a/6.0/6.0.0a2/Dockerfile.python37
+++ b/6.0/6.0.0a2/Dockerfile.python37
@@ -3,6 +3,7 @@ FROM base as builder
 
 ENV PIP_PARAMS="--use-deprecated legacy-resolver"
 ENV PLONE_VERSION=6.0.0a2
+ENV EXTRA_PACKAGES="relstorage==3.4.5 psycopg2-binary==2.9.1"
 
 RUN mkdir /wheelhouse
 
@@ -11,7 +12,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends $buildDeps\
     && rm -rf /var/lib/apt/lists/* /usr/share/doc
 
-RUN pip wheel Plone plone.volto -c https://dist.plone.org/release/$PLONE_VERSION/constraints.txt  ${PIP_PARAMS} --wheel-dir=/wheelhouse
+RUN pip wheel Plone plone.volto ${EXTRA_PACKAGES} -c https://dist.plone.org/release/$PLONE_VERSION/constraints.txt  ${PIP_PARAMS} --wheel-dir=/wheelhouse
 
 FROM base
 
@@ -39,7 +40,6 @@ WORKDIR /app
 RUN python -m venv . \
     && ./bin/pip install -U "pip==${PIP_VERSION}" \
     && ./bin/pip install --force-reinstall --no-index --no-deps ${PIP_PARAMS} /wheelhouse/* \
-    && ./bin/pip install "relstorage==3.4.5" "psycopg2-binary==2.9.1" ${PIP_PARAMS} \
     && find . \( -type f -a -name '*.pyc' -o -name '*.pyo' \) -exec rm -rf '{}' + \
     && rm -rf .cache
 

--- a/6.0/6.0.0a2/Dockerfile.python38
+++ b/6.0/6.0.0a2/Dockerfile.python38
@@ -3,7 +3,7 @@ FROM base as builder
 
 ENV PIP_PARAMS="--use-deprecated legacy-resolver"
 ENV PLONE_VERSION=6.0.0a2
-ENV EXTRA_PACKAGES="relstorage==3.4.5 psycopg2-binary==2.9.1"
+ENV EXTRA_PACKAGES="relstorage==3.4.5 psycopg2==2.9.3"
 
 RUN mkdir /wheelhouse
 

--- a/6.0/6.0.0a2/Dockerfile.python38
+++ b/6.0/6.0.0a2/Dockerfile.python38
@@ -3,6 +3,7 @@ FROM base as builder
 
 ENV PIP_PARAMS="--use-deprecated legacy-resolver"
 ENV PLONE_VERSION=6.0.0a2
+ENV EXTRA_PACKAGES="relstorage==3.4.5 psycopg2-binary==2.9.1"
 
 RUN mkdir /wheelhouse
 
@@ -11,7 +12,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends $buildDeps\
     && rm -rf /var/lib/apt/lists/* /usr/share/doc
 
-RUN pip wheel Plone plone.volto -c https://dist.plone.org/release/$PLONE_VERSION/constraints.txt  ${PIP_PARAMS} --wheel-dir=/wheelhouse
+RUN pip wheel Plone plone.volto ${EXTRA_PACKAGES} -c https://dist.plone.org/release/$PLONE_VERSION/constraints.txt  ${PIP_PARAMS} --wheel-dir=/wheelhouse
 
 FROM base
 
@@ -39,7 +40,6 @@ WORKDIR /app
 RUN python -m venv . \
     && ./bin/pip install -U "pip==${PIP_VERSION}" \
     && ./bin/pip install --force-reinstall --no-index --no-deps ${PIP_PARAMS} /wheelhouse/* \
-    && ./bin/pip install "relstorage==3.4.5" "psycopg2-binary==2.9.1" ${PIP_PARAMS} \
     && find . \( -type f -a -name '*.pyc' -o -name '*.pyo' \) -exec rm -rf '{}' + \
     && rm -rf .cache
 

--- a/6.0/6.0.0a2/Dockerfile.python39
+++ b/6.0/6.0.0a2/Dockerfile.python39
@@ -3,7 +3,7 @@ FROM base as builder
 
 ENV PIP_PARAMS="--use-deprecated legacy-resolver"
 ENV PLONE_VERSION=6.0.0a2
-ENV EXTRA_PACKAGES="relstorage==3.4.5 psycopg2-binary==2.9.1"
+ENV EXTRA_PACKAGES="relstorage==3.4.5 psycopg2==2.9.3"
 
 RUN mkdir /wheelhouse
 

--- a/6.0/6.0.0a2/Dockerfile.python39
+++ b/6.0/6.0.0a2/Dockerfile.python39
@@ -3,6 +3,7 @@ FROM base as builder
 
 ENV PIP_PARAMS="--use-deprecated legacy-resolver"
 ENV PLONE_VERSION=6.0.0a2
+ENV EXTRA_PACKAGES="relstorage==3.4.5 psycopg2-binary==2.9.1"
 
 RUN mkdir /wheelhouse
 
@@ -11,7 +12,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends $buildDeps\
     && rm -rf /var/lib/apt/lists/* /usr/share/doc
 
-RUN pip wheel Plone plone.volto -c https://dist.plone.org/release/$PLONE_VERSION/constraints.txt  ${PIP_PARAMS} --wheel-dir=/wheelhouse
+RUN pip wheel Plone plone.volto ${EXTRA_PACKAGES} -c https://dist.plone.org/release/$PLONE_VERSION/constraints.txt  ${PIP_PARAMS} --wheel-dir=/wheelhouse
 
 FROM base
 
@@ -39,7 +40,6 @@ WORKDIR /app
 RUN python -m venv . \
     && ./bin/pip install -U "pip==${PIP_VERSION}" \
     && ./bin/pip install --force-reinstall --no-index --no-deps ${PIP_PARAMS} /wheelhouse/* \
-    && ./bin/pip install "relstorage==3.4.5" "psycopg2-binary==2.9.1" ${PIP_PARAMS} \
     && find . \( -type f -a -name '*.pyc' -o -name '*.pyo' \) -exec rm -rf '{}' + \
     && rm -rf .cache
 


### PR DESCRIPTION
Since it breaks in M1/ARM64 builds, because gcc is not present in the later base build.

Did we have any reason for it to be installed later?