### PR TITLE
Specify platform in push too, since the images were not being pushed…

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,6 +95,7 @@ jobs:
       - name: Push ${{ matrix.plone-version }} python ${{ matrix.python-version }}
         uses: docker/build-push-action@v2
         with:
+          platforms: linux/amd64,linux/arm64
           push: ${{ needs.collect-build-info.outputs.environment-to-use == '"DOCKER_HUB"' }}
           context: ./${{ matrix.plone-version }}
           file: ./${{ matrix.plone-version }}/Dockerfile.python${{ matrix.python-version }}


### PR DESCRIPTION
… yet.

I realised of the main-test escape hatch, and I tried it out, and it succeeded now :) 

<img width="1293" alt="image" src="https://user-images.githubusercontent.com/486927/148678267-674be59f-cb98-4a58-a63a-e15eda2f9d1d.png">
