### PR TITLE
Fix chown in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ RUN <<EOT
     busybox --install -s
     rm -rf /var/lib/apt/lists/* /usr/share/doc
     mkdir -p /data/filestorage /data/blobstorage /data/log /data/cache
-    chown -R /data plone:plone
+    chown -R plone:plone /data
     ln -s /data /app/var
 EOT
 


### PR DESCRIPTION
 * fix chown by moving `[OWNER][:[GROUP]]` before the `FILE` (like it should be according to the manpage of chown).