### PR TITLE
 Allow changing the listen port for the Zope process.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,10 +49,9 @@ RUN <<EOT
     ln -s /data /app/var
 EOT
 
-EXPOSE 8080
 VOLUME /data
 
-HEALTHCHECK --interval=10s --timeout=5s --start-period=30s CMD wget -q http://127.0.0.1:8080/ok -O - | grep OK || exit 1
+HEALTHCHECK --interval=10s --timeout=5s --start-period=30s CMD [ -n "$LISTEN_PORT" ] || LISTEN_PORT=8080 ; wget -q http://127.0.0.1:$LISTEN_PORT/ok -O - | grep OK || exit 1
 
 ENTRYPOINT [ "/app/docker-entrypoint.sh" ]
 CMD ["start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,7 @@ EOT
 
 VOLUME /data
 
-HEALTHCHECK --interval=10s --timeout=5s --start-period=30s CMD [ -n "$LISTEN_PORT" ] || LISTEN_PORT=8080 ; wget -q http://127.0.0.1:$LISTEN_PORT/ok -O - | grep OK || exit 1
+HEALTHCHECK --interval=10s --timeout=5s --start-period=30s CMD [ -n "$LISTEN_PORT" ] || LISTEN_PORT=8080 ; wget -q http://127.0.0.1:"$LISTEN_PORT"/ok -O - | grep OK || exit 1
 
 ENTRYPOINT [ "/app/docker-entrypoint.sh" ]
 CMD ["start"]

--- a/news/69.feature
+++ b/news/69.feature
@@ -1,0 +1,1 @@
+* Permit changing of listening port from the default 8080 [Rudd-O]

--- a/skeleton/docker-entrypoint.sh
+++ b/skeleton/docker-entrypoint.sh
@@ -100,6 +100,11 @@ if [[ "$1" == "start" ]]; then
     $sudo $VENVBIN/zconsole run etc/${CONF} /app/scripts/create_site.py
   fi
   echo $MSG
+  if [ -n ${LISTEN_PORT} ] ; then
+    # Ensure the listen port can be set via container --environment.
+    # Necessary to run multiple backends in a single Podman / Kubernetes pod.
+    sed -i "s/port = 8080/port = $LISTEN_PORT/" etc/zope.ini
+  fi
   exec $sudo $VENVBIN/runwsgi -v etc/zope.ini config_file=${CONF}
 elif  [[ "$1" == "create-classic" ]]; then
   export TYPE=classic

--- a/skeleton/docker-entrypoint.sh
+++ b/skeleton/docker-entrypoint.sh
@@ -103,7 +103,7 @@ if [[ "$1" == "start" ]]; then
   if [[ -v LISTEN_PORT ]] ; then
     # Ensure the listen port can be set via container --environment.
     # Necessary to run multiple backends in a single Podman / Kubernetes pod.
-    sed -i "s/port = 8080/port = $LISTEN_PORT/" etc/zope.ini
+    sed -i "s/port = 8080/port = ${LISTEN_PORT}/" etc/zope.ini
   fi
   exec $sudo $VENVBIN/runwsgi -v etc/zope.ini config_file=${CONF}
 elif  [[ "$1" == "create-classic" ]]; then

--- a/skeleton/docker-entrypoint.sh
+++ b/skeleton/docker-entrypoint.sh
@@ -100,7 +100,7 @@ if [[ "$1" == "start" ]]; then
     $sudo $VENVBIN/zconsole run etc/${CONF} /app/scripts/create_site.py
   fi
   echo $MSG
-  if [ -n ${LISTEN_PORT} ] ; then
+  if [[ -v LISTEN_PORT ]] ; then
     # Ensure the listen port can be set via container --environment.
     # Necessary to run multiple backends in a single Podman / Kubernetes pod.
     sed -i "s/port = 8080/port = $LISTEN_PORT/" etc/zope.ini

--- a/test/config.sh
+++ b/test/config.sh
@@ -13,6 +13,7 @@ imageTests+=(
 		plone-addons
 		plone-cors
 		plone-arbitrary-user
+		plone-listenport
 		plone-zeoclient
 		plone-relstorage
 		plone-shared-blob-dir

--- a/test/tests/plone-listenport/run.sh
+++ b/test/tests/plone-listenport/run.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -eo pipefail
+
+dir="$(dirname "$(readlink -f "$BASH_SOURCE")")"
+
+image="$1"
+
+PLONE_TEST_SLEEP=3
+PLONE_TEST_TRIES=5
+
+cname="plone-container-$RANDOM-$RANDOM"
+cid="$(docker run -d --name "$cname" -e LISTEN_PORT=8081 "$image")"
+trap "docker rm -vf $cid > /dev/null" EXIT
+
+get() {
+	docker run --rm -i \
+		--link "$cname":plone \
+		--entrypoint /app/bin/python \
+		"$image" \
+		-c "from six.moves.urllib.request import urlopen; con = urlopen('$1'); print(con.read())"
+}
+
+. "$dir/../../retry.sh" --tries "$PLONE_TEST_TRIES" --sleep "$PLONE_TEST_SLEEP" get "http://plone:8081"
+
+# Plone is up and running
+[[ "$(get 'http://plone:8081')" == *"Plone is up and running"* ]]


### PR DESCRIPTION
Supersedes https://github.com/plone/plone-backend/pull/69/files because tests are broken when testing PRs coming from forks.