### PR TITLE
Add zope.conf.d configuration feature.

### DIFF
--- a/news/92.feature
+++ b/news/92.feature
@@ -1,0 +1,1 @@
+* Allow users of derived containers to drop in Zope configuration snippets [Rudd-O]

--- a/skeleton/docker-entrypoint.sh
+++ b/skeleton/docker-entrypoint.sh
@@ -69,8 +69,8 @@ fi
 # functionality, but for Zope configuration snippets.
 for f in etc/zope.conf.d/*.conf ; do
   test -f ${f} || continue
-  echo >> ${CONF}
-  cat ${f} >> ${CONF}
+  echo >> etc/${CONF}
+  cat ${f} >> etc/${CONF}
 done
 
 # Handle CORS

--- a/skeleton/docker-entrypoint.sh
+++ b/skeleton/docker-entrypoint.sh
@@ -63,6 +63,16 @@ else
   CONF=zope.conf
 fi
 
+# Add anything inside etc/zope.conf.d to the configuration file
+# prior to starting the respective Zope server.
+# This provides a counterpart for the ZCML package-includes
+# functionality, but for Zope configuration snippets.
+for f in etc/zope.conf.d/*.conf ; do
+  test -f ${f} || continue
+  echo >> ${CONF}
+  cat ${f} >> ${CONF}
+done
+
 # Handle CORS
 $sudo $VENVBIN/python /app/scripts/cors.py
 


### PR DESCRIPTION
This permits implementors who derive from this container to simply drop additional zope.conf snippets that get added prior to starting the Zope process.  This is the counterpart of the ZCML fragment configuration feature.

Packages that require Zope configuration snippets include haufe.requestmonitoring -- any package which requires zope conf additional in buildout can then be run inside a container.

Documentation: https://github.com/plone/documentation/pull/1359