### PR TITLE
Allow ADDONS to be present, but empty

### DIFF
--- a/news/102.bugfix
+++ b/news/102.bugfix
@@ -1,0 +1,1 @@
+Allow ADDONS to be present, but empty @sneridagh

--- a/skeleton/docker-entrypoint.sh
+++ b/skeleton/docker-entrypoint.sh
@@ -97,7 +97,7 @@ fi
 $sudo $VENVBIN/python /app/scripts/cors.py
 
 # Handle ADDONS installation
-if [[ -z "${ADDONS}" ]]; then
+if [[ -n "${ADDONS}" ]]; then
   echo "======================================================================================="
   echo "Installing ADDONS ${ADDONS}"
   echo "THIS IS NOT MEANT TO BE USED IN PRODUCTION"

--- a/skeleton/docker-entrypoint.sh
+++ b/skeleton/docker-entrypoint.sh
@@ -97,7 +97,7 @@ fi
 $sudo $VENVBIN/python /app/scripts/cors.py
 
 # Handle ADDONS installation
-if [[ -v ADDONS ]]; then
+if [[ -z "${ADDONS}" ]]; then
   echo "======================================================================================="
   echo "Installing ADDONS ${ADDONS}"
   echo "THIS IS NOT MEANT TO BE USED IN PRODUCTION"


### PR DESCRIPTION
Useful for Makefiles that state ADDONS as a var, but at some point this var is empty and the docker command turns out:

`docker run -it --rm --name=backend -p 8080:8080 -e SITE=Plone -e ADDONS= plone/plone-backend:6.0.0rc1`

closes: https://github.com/plone/volto/issues/4022