### PR TITLE
Increase the healthcheck startup time to 60s

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -38,7 +38,7 @@ EXPOSE 8080
 WORKDIR /app
 
 # Set healthcheck to port 8080
-HEALTHCHECK --interval=10s --timeout=5s --start-period=30s CMD [ -n "$LISTEN_PORT" ] || LISTEN_PORT=8080 ; wget -q http://127.0.0.1:"$LISTEN_PORT"/ok -O - | grep OK || exit 1
+HEALTHCHECK --interval=10s --timeout=5s --start-period=60s CMD [ -n "$LISTEN_PORT" ] || LISTEN_PORT=8080 ; wget -q http://127.0.0.1:"$LISTEN_PORT"/ok -O - | grep OK || exit 1
 
 ENTRYPOINT [ "/app/docker-entrypoint.sh" ]
 CMD ["start"]


### PR DESCRIPTION
30s is not enough on the first boot when the site is being created. Fixes https://github.com/collective/cookiecutter-plone-starter/issues/76, hopefully