### PR TITLE
Remove fallback to pkg_resources, since we use pip>23.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,6 @@ COPY --from=builder --chown=500:500 /app /app
 # Enable compilation of po files into mo files (This is added here for backward compatibility)
 
 ENV zope_i18n_compile_mo_files=true
-# https://github.com/pypa/pip/issues/12079
-ENV _PIP_USE_IMPORTLIB_METADATA=0
 
 # Link /data (the exposed volume) into /app/var
 RUN ln -s /data /app/var

--- a/Dockerfile.acceptance
+++ b/Dockerfile.acceptance
@@ -32,8 +32,6 @@ ENV LISTEN_PORT=${ZSERVER_PORT}
 ENV APPLY_PROFILES=plone.app.contenttypes:plone-content,plone.restapi:default,plone.volto:default-homepage
 # Packages to be used in configuration
 ENV CONFIGURE_PACKAGES=plone.app.contenttypes,plone.restapi,plone.volto,plone.volto.cors
-# https://github.com/pypa/pip/issues/12079
-ENV _PIP_USE_IMPORTLIB_METADATA=0
 
 RUN ln -s /data /app/var
 

--- a/Dockerfile.classicui
+++ b/Dockerfile.classicui
@@ -24,5 +24,3 @@ RUN ln -s /data /app/var
 
 # Setup default type for site creation to be classic
 ENV TYPE=classic
-# https://github.com/pypa/pip/issues/12079
-ENV _PIP_USE_IMPORTLIB_METADATA=0

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -28,8 +28,6 @@ ENV DEBUG_MODE on
 ENV zope_i18n_compile_mo_files=
 # Set chameleon cache directory
 ENV CHAMELEON_CACHE /app/var/cache
-# https://github.com/pypa/pip/issues/12079
-ENV _PIP_USE_IMPORTLIB_METADATA=0
 # Expose Zope Port
 EXPOSE 8080
 


### PR DESCRIPTION
We added an environment variable to let pip < 23.2 fal back to using pkg_resources instead of importlib_metadata because ther was a regression.   this was solved in pip 23.2, release around July 2023 and our recent Plone releases all use this pip or newer. 

https://github.com/pypa/pip/issues/12079