### PR TITLE
Switch to ubuntu-22.04 in workflows.

### DIFF
--- a/.github/workflows/description.yml
+++ b/.github/workflows/description.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   update-description:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     environment: DOCKER_HUB
     steps:
       - name: Checkout

--- a/.github/workflows/image-release.yml
+++ b/.github/workflows/image-release.yml
@@ -40,7 +40,7 @@ on:
 jobs:
 
   release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     environment: DOCKER_HUB
     steps:
       - name: Checkout

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -8,7 +8,7 @@ on:
 jobs:
 
   release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     environment: DOCKER_HUB
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ env:
 jobs:
 
   meta:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       BASE_IMAGE_NAME: ${{ steps.vars.outputs.BASE_IMAGE_NAME }}
       IS_LATEST: ${{ steps.vars.outputs.IS_LATEST }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ on:
 jobs:
 
   meta:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       SHA: ${{ steps.vars.outputs.SHA }}
       PLONE_VERSION: ${{ steps.vars.outputs.PLONE_VERSION }}
@@ -26,7 +26,7 @@ jobs:
           echo "PLONE_VERSION=$(cat version.txt)" >> $GITHUB_OUTPUT
 
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     environment: DOCKER_HUB
     needs:
       - meta


### PR DESCRIPTION
See [my comment here](https://github.com/plone/plone-backend/pull/159#issuecomment-2627125204). Let me copy that:

> I tagged v6.1.0rc1, but the GitHub action [fails](https://github.com/plone/plone-backend/actions/runs/13071667764/job/36474485822#step:8:3603):
> 
> ```
> Failed to build installable wheels for some pyproject.toml based projects
> (relstorage, python-ldap)
> ```
> 
> We are using ubuntu-latest, which is now ubuntu-24.04, which may need some changes.  We could for now switch to ubuntu-22.04.
> 

It can probably be truly fixed by installing some more OS packages, or maybe use newer versions of relstorage and python-ldap that have matching binary wheels on PyPI.  But the old Ubuntu is the quickest fix.

Maybe the change is only needed in one of these files.
Can't really test this without actually merging this and making a fresh tag, I guess.