### PR TITLE
Fix acceptance image

### DIFF
--- a/Dockerfile.acceptance
+++ b/Dockerfile.acceptance
@@ -31,7 +31,7 @@ ENV ZSERVER_PORT=55001
 # This fixes the healthcheck defined in server-prod-config
 ENV LISTEN_PORT=${ZSERVER_PORT}
 # Profiles to be added to the created site
-ENV APPLY_PROFILES=plone.app.contenttypes:plone-content,plone.restapi:default,plone.volto:default-homepage
+ENV APPLY_PROFILES=plone.app.contenttypes:plone-content,plone.restapi:default
 # Packages to be used in configuration
 ENV CONFIGURE_PACKAGES=plone.app.contenttypes,plone.restapi,plone.volto,plone.volto.cors
 


### PR DESCRIPTION
remove plone.volto:default-homepage from it

@mauritsvanrees @fredvd this image is broken in 6.1.0rc1 we need a re-release of the images, once this is merged.

Until this is not done, updating Volto will be red:
https://github.com/plone/volto/actions/runs/13174806500/job/36771636755?pr=6682
and no projects using Cypress tests could use the rc1.

