### PR TITLE
Use SITE_LANGUAGE environment variable instead of LANGUAGE

### DIFF
--- a/skeleton/scripts/create_site.py
+++ b/skeleton/scripts/create_site.py
@@ -69,9 +69,9 @@ if DISTRIBUTION:
 SITE_ID = os.getenv("SITE_ID")
 if SITE_ID:
     answers["site_id"] = SITE_ID
-LANGUAGE = os.getenv("LANGUAGE")
-if LANGUAGE:
-    answers["default_language"] = LANGUAGE
+SITE_LANGUAGE = os.getenv("SITE_LANGUAGE")
+if SITE_LANGUAGE:
+    answers["default_language"] = SITE_LANGUAGE
 SETUP_CONTENT = os.getenv("SETUP_CONTENT")
 if SETUP_CONTENT is not None:
     answers["setup_content"] = asbool(SETUP_CONTENT)


### PR DESCRIPTION
The `LANGUAGE` variable is already set and used by the OS.

Fixes plone/volto#6404