### PR TITLE
Backport for 6.0: Add addzopeuser command to docker-entrypoint (#175)

### DIFF
--- a/skeleton/docker-entrypoint.sh
+++ b/skeleton/docker-entrypoint.sh
@@ -160,6 +160,8 @@ elif  [[ "$1" == "console" ]]; then
   exec $sudo $VENVBIN/zconsole debug etc/${CONF}
 elif  [[ "$1" == "run" ]]; then
   exec $sudo $VENVBIN/zconsole run etc/${CONF} "${@:2}"
+elif  [[ "$1" == "addzopeuser" ]]; then
+  exec $sudo $VENVBIN/addzopeuser -c etc/${CONF} "${@:2}"
 else
   # Custom
   exec "$@"


### PR DESCRIPTION
This makes it easier to run the addzopeuser script with the correct conf. Relevant to https://github.com/plone/documentation/pull/1869