### PR TITLE
compile po files in the sources folder

### DIFF
--- a/helpers/compile_mo.py
+++ b/helpers/compile_mo.py
@@ -50,14 +50,19 @@ def compile_po_file(po_file: Path) -> Path | None:
 
 
 def main():
-    lib_path: Path = Path(f"{APP_FOLDER}/lib").resolve()
-    po_files: Generator= lib_path.glob("**/*.po")
     mo_files: list = []
-    logger.info("Starting compilation of po files")
-    for po_file in po_files:
-        mo_file = compile_po_file(po_file)
-        if mo_file:
-            mo_files.append(mo_file)
+    lib_paths: list = []
+    lib_paths = [
+        Path(f"{APP_FOLDER}/lib").resolve(),
+        Path(f"{APP_FOLDER}/src/sources").resolve(),
+    ]
+    for lib_path in lib_paths:
+        po_files: Generator = lib_path.glob("**/*.po")
+        logger.info("Starting compilation of po files")
+        for po_file in po_files:
+            mo_file = compile_po_file(po_file)
+            if mo_file:
+                mo_files.append(mo_file)
     logger.info(f"Compiled {len(mo_files)} files")
 
 

--- a/news/189.feat
+++ b/news/189.feat
@@ -1,0 +1,1 @@
+Compile po files in the sources folder, where by default the packages from mx.ini are downloaded @erral


### PR DESCRIPTION
This way, we can compile the `po` files of the packages downloaded using `mxdev` and referenced in `mx.ini`