### PR TITLE
feat: add an environment var to skip the find-and-chown

### DIFF
--- a/skeleton/docker-entrypoint.sh
+++ b/skeleton/docker-entrypoint.sh
@@ -16,7 +16,9 @@ USER="$(id -u)"
 # Create directories to be used by Plone
 mkdir -p /data/filestorage /data/blobstorage /data/cache /data/log $CLIENT_HOME
 if [ "$USER" = '0' ]; then
-  find /data -not -user plone -exec chown plone:plone {} \+
+  if [[ ! -v SKIP_FIND_AND_CHOWN ]]; then
+    find /data -not -user plone -exec chown plone:plone {} \+
+  fi
   sudo="gosu plone"
 else
   sudo=""


### PR DESCRIPTION
- [ ] I signed and returned the [Plone Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the Plone GitHub organization.
- [ ] I verified there aren't any other open pull requests for the same change.
- [ ] I followed the guidelines in [Contributing to Plone](https://6.docs.plone.org/contributing/index.html).
- [ ] I successfully ran code quality checks on my changes locally.
- [ ] I successfully ran tests on my changes locally.
- [ ] If needed, I added new tests for my changes.
- [ ] If needed, I added [documentation](https://6.docs.plone.org/contributing/documentation/index.html) for my changes.
- [ ] I included a [change log entry](https://6.docs.plone.org/contributing/index.html#contributing-change-log-label) in my commits.

-----

If your pull request closes an open issue, include the exact text below, immediately followed by the issue number. When your pull request gets merged, then that issue will close automatically.

Addresses #172 

I don't know whether this is acceptable at all, but we are creating our base docker images for Plone that do not do this `find-and-chown` thing, because we run Plone with ZEO as storage, and when you have a log of blobs it takes a lot of time to start.

That's why I decided to add an environment var, that if set, avoids doing the find-and-chown thing.

I have added the documentation in the documentation repo: https://github.com/plone/documentation/pull/2035





