### PR TITLE
Update docker entrypoint

### DIFF
--- a/news/+exporter.feature
+++ b/news/+exporter.feature
@@ -1,0 +1,2 @@
+Add `export` to the commands available via docker-entrypoint.sh . @ericof
+  - Usage is ./docker-entrypoint.sh <SITE_ID> <PATH_TO_EXPORT_SITE_DATA>

--- a/news/+instrumentation.feature
+++ b/news/+instrumentation.feature
@@ -1,0 +1,1 @@
+Add support to instrument `runwsgi` by setting the environment variable INSTRUMENTATION_CMD, that should be the name of a command present in the Python virtual environment. @ericof

--- a/news/+zope-ini.feature
+++ b/news/+zope-ini.feature
@@ -1,0 +1,1 @@
+Support providing a different path to zope.ini by setting the environment variable ZOPE_INI_PATH . @ericof

--- a/skeleton/docker-entrypoint.sh
+++ b/skeleton/docker-entrypoint.sh
@@ -22,6 +22,19 @@ else
   sudo=""
 fi
 
+# Instrumentation support
+if [[ -v INSTRUMENTATION_CMD ]] ; then
+  echo "Enabling Instrumentation using $INSTRUMENTATION_CMD command"
+  WSGI_CMD=("$VENVBIN/$INSTRUMENTATION_CMD" "$VENVBIN/runwsgi")
+else
+  WSGI_CMD=("$VENVBIN/runwsgi")
+fi
+
+# Allow pointing to a different Zope ini path
+if [ -z "${ZOPE_INI_PATH}" ]; then
+  ZOPE_INI_PATH=etc/zope.ini
+fi
+
 # MAIN ENV Vars
 [ -z ${SECURITY_POLICY_IMPLEMENTATION+x} ] && export SECURITY_POLICY_IMPLEMENTATION=C
 [ -z ${VERBOSE_SECURITY+x} ] && export VERBOSE_SECURITY=off
@@ -145,9 +158,9 @@ if [[ "$1" == "start" ]]; then
   if [[ -v LISTEN_PORT ]] ; then
     # Ensure the listen port can be set via container --environment.
     # Necessary to run multiple backends in a single Podman / Kubernetes pod.
-    sed -i "s/port = 8080/port = ${LISTEN_PORT}/" etc/zope.ini
+    sed -i "s/port = 8080/port = ${LISTEN_PORT}/" "${ZOPE_INI_PATH}"
   fi
-  exec $sudo $VENVBIN/runwsgi -v etc/zope.ini config_file=${CONF}
+  exec $sudo "${WSGI_CMD[@]}" -v "${ZOPE_INI_PATH}" config_file=${CONF}
 elif  [[ "$1" == "create-classic" ]]; then
   export TYPE=classic
   exec $sudo $VENVBIN/zconsole run etc/${CONF} /app/scripts/create_site.py

--- a/skeleton/docker-entrypoint.sh
+++ b/skeleton/docker-entrypoint.sh
@@ -159,6 +159,8 @@ elif  [[ "$1" == "create-site" ]]; then
   exec $sudo $VENVBIN/zconsole run etc/${CONF} /app/scripts/create_site.py
 elif  [[ "$1" == "console" ]]; then
   exec $sudo $VENVBIN/zconsole debug etc/${CONF}
+elif  [[ "$1" == "export" ]]; then
+  exec $sudo $VENVBIN/plone-exporter etc/${CONF} "${@:2}" "${@:3}"
 elif  [[ "$1" == "import" ]]; then
   exec $sudo $VENVBIN/plone-importer etc/${CONF} "${@:2}" "${@:3}"
 elif  [[ "$1" == "run" ]]; then


### PR DESCRIPTION
# Changes
- [X] Add a `export` sub-command
- [X] Support instrumenting the `runwsgi` process by setting the `INSTRUMENTATION_CMD` environment variable
- [X] Support specifying a different zope.ini path by setting the `ZOPE_INI_PATH` environment variable

## About `zope.ini`

This file uses [PasteDeploy](https://docs.pylonsproject.org/projects/pastedeploy/en/latest/) and from what I can see, it does not support environment variables. (But I need to research a bit more because I do remember patching it in websauna do to so). Thanks to that, adding new filters to the existing pipeline is not an easy task, that is why I decided to have this ZOPE_INI_PATH as an alternative way to have one container supporting customizations to this file if a flag is set.