### PR TITLE
Add weekly scheduled rebuild for UV-based images (closes #203)

### DIFF
--- a/.github/workflows/schedule-uv.yml
+++ b/.github/workflows/schedule-uv.yml
@@ -1,0 +1,28 @@
+name: Schedule UV image rebuild
+
+on:
+  schedule:
+    # Weekly, Mondays at 05:00 UTC — keeps UV-based images aligned with
+    # upstream Debian, Python, UV and Plone dependency updates.
+    - cron: "0 5 * * 1"
+  workflow_dispatch:
+
+env:
+  branch: uv
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  dispatch:
+    name: Dispatch release-uv on the uv branch
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger release-uv workflow
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run release-uv.yml \
+            --repo "${{ github.repository }}" \
+            --ref ${{ env.branch }}

--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ These images are **not** Buildout based!
 Please note that the backend images in the 6.1.x series have several updated dependencies, which you should verify and test before using them in any existing project. Even if you extend from these images. The underlying OS has been switched from Debian 11 buster to 12 bookworm. Python is updated from
 3.11 to 3.12. Relstorage has a new major release going from 3.x to 4.1. And there are are minor updates for libldap, libtiff and psycopg2 OS and Python libraries.
 
+### Experimental UV-based images
+
+A parallel track of images built with [UV](https://docs.astral.sh/uv/) lives on the [`uv` branch](https://github.com/plone/plone-backend/tree/uv) and is published as `plone/server-builder:uv-<python>` and `plone/server-prod-config:uv-<python>` for Python 3.11, 3.12, 3.13 and 3.14. These images are rebuilt weekly (Mondays, 05:00 UTC) so they stay in sync with upstream Debian, Python, UV and Plone dependency updates.
+
 ### Unsupported tags
 
 **Note:**

--- a/news/203.internal
+++ b/news/203.internal
@@ -1,0 +1,1 @@
+Added a scheduled workflow that dispatches the UV image build weekly to keep images in sync with upstream changes. @ericof


### PR DESCRIPTION
## Summary

Wire up the weekly rebuild promised in #203:

- Add `.github/workflows/schedule-uv.yml` on the default branch. It fires weekly on Mondays at 05:00 UTC (and can be triggered manually) and dispatches `release-uv.yml` on the `uv` branch via `gh workflow run ... --ref uv`.
- Document the UV-based images and their weekly refresh cadence in `README.md`.

### Why a dispatcher workflow instead of a `schedule:` on `release-uv.yml` directly?

GitHub Actions only fires `schedule:` triggers from workflow files on the **default branch**. `release-uv.yml` lives on the `uv` branch, so a `schedule:` trigger added there would silently never fire. Landing the schedule on `6.1.x` and having it dispatch the uv-branch workflow via `workflow_dispatch` keeps the build logic where the source lives and avoids duplicating the matrix build on two branches.

The dispatch step relies on a documented exception: `workflow_dispatch` events fired by the default `GITHUB_TOKEN` *do* start new workflow runs (most other token-triggered events don't). No PAT is required — just `permissions: actions: write`.

### Tag strategy

`image-release.yml` already tags images as `plone/server-{builder,prod-config}:uv-<python>`, so scheduled rebuilds transparently overwrite the existing tags. Consumers pulling `uv-3.13` always get the most recent rebuild, which matches the goal of "stay in sync with upstream".

## Test plan

- [ ] Merge this PR and confirm `Schedule UV image rebuild` appears in the Actions tab on `6.1.x`.
- [ ] Manually run the workflow via `workflow_dispatch` and confirm it successfully dispatches `release-uv.yml` on the `uv` ref.
- [ ] After the dispatched build completes, verify fresh digests for `plone/server-builder:uv-3.12` (and siblings) on GHCR and Docker Hub.
- [ ] Observe the first real scheduled run on the following Monday and confirm images rebuild without intervention.

Closes #203