### PR TITLE
Make sure proxy configuration is not used for backend healthcheck

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -43,7 +43,7 @@ EXPOSE 8080
 WORKDIR /app
 
 # Set healthcheck to port 8080
-HEALTHCHECK --interval=10s --timeout=5s --start-period=60s CMD [ -n "$LISTEN_PORT" ] || LISTEN_PORT=8080 ; wget -q http://127.0.0.1:"$LISTEN_PORT"/ok -O - | grep OK || exit 1
+HEALTHCHECK --interval=10s --timeout=5s --start-period=60s CMD [ -n "$LISTEN_PORT" ] || LISTEN_PORT=8080 ; wget -Y off -q http://127.0.0.1:"$LISTEN_PORT"/ok -O - | grep OK || exit 1
 
 ENTRYPOINT [ "/app/docker-entrypoint.sh" ]
 CMD ["start"]


### PR DESCRIPTION
(Busybox wget pays attention to http_proxy/https_proxy but not no_proxy)
