### PR TITLE
test.yml: run on self-hosted [6.1.x]

### DIFF
--- a/.github/workflows/description.yml
+++ b/.github/workflows/description.yml
@@ -14,7 +14,7 @@ jobs:
     environment: DOCKER_HUB
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Update repo description
         uses: peter-evans/dockerhub-description@v4

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -35,7 +35,7 @@ jobs:
         uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to DockerHub
         uses: docker/login-action@v3

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -14,11 +14,11 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           # list of Docker images to use as base name for tags
           images: |
@@ -32,19 +32,19 @@ jobs:
             type=schedule,pattern=nightly-{{date 'YYYYMMDD'}}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
       - name: Login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v7
         with:
           platforms: linux/amd64,linux/arm64
           context: .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       PLONE_VERSION: ${{ steps.vars.outputs.PLONE_VERSION }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set BASE_IMAGE_NAME, IS_LATEST, PLATFORMS, PLONE_VERSION
         id: vars

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
           echo "PLONE_VERSION=$(cat version.txt)" >> $GITHUB_OUTPUT
 
   test:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, ARM64, stable]
     environment: DOCKER_HUB
     needs:
       - meta

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,7 +63,7 @@ jobs:
             type=sha
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to Docker Hub Container Registry
         uses: docker/login-action@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       PLONE_VERSION: ${{ steps.vars.outputs.PLONE_VERSION }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Compute SHA value to be used in building the main image
         id: vars
@@ -33,11 +33,11 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Builder Image
         id: meta-builder
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: |
             plone/server-builder
@@ -46,7 +46,7 @@ jobs:
 
       - name: Prod Config Image
         id: meta-prod-config
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: |
             plone/server-prod-config
@@ -55,7 +55,7 @@ jobs:
 
       - name: Main Image
         id: meta-main
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: |
             plone/plone-backend
@@ -66,13 +66,13 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       - name: Login to Docker Hub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build builder image for testing
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v7
         with:
           context: ./
           file: Dockerfile.builder
@@ -82,7 +82,7 @@ jobs:
             PLONE_VERSION=${{ needs.meta.outputs.PLONE_VERSION }}
 
       - name: Build prod-config image for testing
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v7
         with:
           context: ./
           file: Dockerfile.prod
@@ -90,7 +90,7 @@ jobs:
           push: true
 
       - name: Build main image for testing
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v7
         with:
           context: ./
           file: Dockerfile


### PR DESCRIPTION
Currently, `test.yml` works, see [this run](https://github.com/plone/plone-backend/actions/runs/28202581450) from PR #421, which upgrades to Plone 6.1.5.

But then the release of 6.1.5 (via `image-release.yml`) fails, see [this run](https://github.com/plone/plone-backend/actions/runs/28202583156/job/83626409863).

Big difference: the release runs on `self-hosted`.

Let's first see if `test.yml` also starts failing when run on `self-hosted`.

Then we can see if we can fix that.  It goes wrong in `docker/setup-buildx-action@v3`:

```
Error response from daemon:
failed to stat parent:
stat /var/lib/containerd-stargz-grpc/snapshotter/snapshots/15190/fs:
no such file or directory
```

There are lots of differences between self-hosted and the standard ubuntu, some older, some newer. An obvious thing to try it just to move to latest `docker/setup-buildx-action@v4`. But that is for later.

BTW, 6.2.1 has the same problem.  But let's try on one branch for now.