### PR TITLE
Fix the nightly image.

### DIFF
--- a/Dockerfile.nightly
+++ b/Dockerfile.nightly
@@ -1,11 +1,11 @@
 # syntax=docker/dockerfile:1
-ARG PYTHON_VERSION=3.13
+ARG PYTHON_VERSION=3.14
 FROM python:${PYTHON_VERSION}-slim-bookworm AS base
 FROM base AS builder
 
 ENV PIP_PARAMS=""
-ENV PIP_VERSION=24.3.1
-ENV EXTRA_PACKAGES="relstorage==4.1.1 psycopg2==2.9.10 python-ldap==3.4.4"
+ENV PIP_VERSION=26.1.2
+ENV EXTRA_PACKAGES="relstorage==4.3.0 psycopg2==2.9.12 python-ldap==3.4.7"
 
 RUN mkdir /wheelhouse
 
@@ -15,11 +15,11 @@ RUN <<EOT
     buildDeps="build-essential curl libbz2-dev libffi-dev libjpeg62-turbo-dev libsasl2-dev libldap2-dev libopenjp2-7-dev libpcre3-dev libpq-dev libssl-dev libtiff6 libtiff5-dev libxml2-dev libxslt1-dev wget unzip zlib1g-dev"
     apt-get install -y --no-install-recommends $buildDeps
     pip install -U "pip==${PIP_VERSION}"
-    pip install -U "zc.buildout==4.0" "wheel==0.45.1"
+    pip install -U "zc.buildout==5.2.0.0" "wheel==0.47.0" "setuptools==81.0.0"
     rm -rf /var/lib/apt/lists/* /usr/share/doc
-    curl -L -o workspace.zip https://github.com/plone/buildout.coredev/archive/refs/heads/6.1.zip
+    curl -L -o workspace.zip https://github.com/plone/buildout.coredev/archive/refs/heads/6.2.zip
     unzip workspace.zip
-    mv buildout.coredev-6.1 /workspace
+    mv buildout.coredev-6.2 /workspace
 EOT
 
 WORKDIR /workspace
@@ -36,11 +36,11 @@ EOT
 FROM base
 
 ENV PIP_PARAMS=""
-ENV PIP_VERSION=24.3.1
+ENV PIP_VERSION=26.1.2
 
 LABEL maintainer="Plone Community <dev@plone.org>" \
       org.label-schema.name="plone-backend" \
-      org.label-schema.description="Plone backend image using Python 3.10" \
+      org.label-schema.description="Plone 6.2 nightly backend image using Python 3.14" \
       org.label-schema.vendor="Plone Foundation"
 
 COPY --from=builder /wheelhouse /wheelhouse


### PR DESCRIPTION
I have daily been getting an error about the nightly image job failing.

It [fails](https://github.com/plone/plone-backend/actions/runs/29706368959/job/88243965444#step:7:1081) with: `ModuleNotFoundError: No module named 'pkg_resources'` This is because we have a too new `setuptools` version, which fails with any version of `zc.buildout`. And we need `zc.buildout` in our `pip-from-buildout-coredev.py` helper script.

Actually we could probably rewrite this to use code from `plone.releaser`. Or really nothing like that should be needed, because the coredev buildout already keeps the pip files up to date.

So this part could need a bit of rethinking.  Also see if we want to maintain a nightly image at all. The [workflow runs](https://github.com/plone/plone-backend/actions/workflows/nightly.yml) go back to June last year, and I don't see a single one that passes.  They all seem to have the same error.

Anyway, let's fix the immediate error by explicitly using `setuptools` 81.

Also upgrade other versions:

* Python 3.13 to 3.14
* Plone coredev branch 6.1 to 6.2
* Latest from requirements.txt
* Update other packages, like pip and Relstorage
